### PR TITLE
Escape ampersand character in the workshop name

### DIFF
--- a/mlrsa_2020.sty
+++ b/mlrsa_2020.sty
@@ -73,11 +73,11 @@
 \else
   \if@neuripsfinal
     \newcommand{\@noticestring}{%
-  NeurIPS 2020 Workshop: ML Retrospectives, Surveys & Meta-Analyses (ML-RSA).
+  NeurIPS 2020 Workshop: ML Retrospectives, Surveys \& Meta-Analyses (ML-RSA).
     }
   \else
     \newcommand{\@noticestring}{%
-      Submitted to ML Retrospectives, Surveys & Meta-Analyses (ML-RSA) Workshop.%
+      Submitted to ML Retrospectives, Surveys \& Meta-Analyses (ML-RSA) Workshop.%
     }
 
     % hide the acknowledgements


### PR DESCRIPTION
Without this change my latex compiler was throwing an error `Misplaced alignment tab character &` immediately after `\maketitle` command. With this change everything compiles fine.